### PR TITLE
Add imperial gas meter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Data is returned in kw.
 
 **Experimental Gas Meter Support**
 
-The gas meter support is experimental and not all gas meters are properly supported yet - so if the data you see doesn't agree with the readings you see via loop energy please report an issue, and if you're a developer please investigate the data that's being returned from your meter and compare it to the data from my meter listed here https://github.com/pavoni/pyloopenergy/blob/master/pyloopenergy/loop_energy.py#L146-156. 
+The gas meter support is experimental and not all gas meters are properly supported yet - so if the data you see doesn't agree with the readings you see via loop energy please report an issue, and if you're a developer please investigate the data that's being returned from your meter and compare it to the data from my meter listed here https://github.com/pavoni/pyloopenergy/blob/master/pyloopenergy/loop_energy.py#L146-156.
 
 I hope to support more meter types if we can work out what the readings mean. Contributions are very welcome!
 
@@ -78,4 +78,28 @@ Gas = 0.0
 Electricity = 1.116
 ````
 
-The gas code assumes that the meter is a metric meter - and I've added come comments on the info that I suspect specifies my meter type. Enhancements welcome for other meter types!
+
+Gas Meter Types and Calorific values
+---------
+
+The library supports metric and imperial gas meters (reading cubic metres or 100s of cubic feet)
+
+The default is a metric meter, but you can specify an imperial or metric meter.
+
+````
+le = pyloopenergy.LoopEnergy(elec_serial, elec_secret, gas_serial, gas_secret, pyloopemergy.IMPERIAL)
+
+le = pyloopenergy.LoopEnergy(elec_serial, elec_secret, gas_serial, gas_secret, pyloopemergy.METRIC)
+
+````
+
+To convert from a volume reading into kw, the library needs to know how much energy is in each metre of gas. The default is 39.11, but you can use the real number from your supplier if you like.
+
+````
+le = pyloopenergy.LoopEnergy(elec_serial, elec_secret, gas_serial, gas_secret, pyloopemergy.IMPERIAL, 39.1)
+
+le = pyloopenergy.LoopEnergy(elec_serial, elec_secret, gas_serial, gas_secret, pyloopemergy.METRIC, 39.1)
+
+````
+
+

--- a/pyloopenergy/__init__.py
+++ b/pyloopenergy/__init__.py
@@ -3,3 +3,5 @@
 Python module to access Loop Energy energy monitors via Socket.Io API.
 """
 from .loop_energy import LoopEnergy
+from .loop_energy import IMPERIAL
+from .loop_energy import METRIC

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pyloopenergy',
-      version='0.0.8',
+      version='0.0.9',
       description='Access Loop Energy energy monitors via Socket.IO API',
       url='http://github.com/pavoni/pyloopenergy',
       author='Greg Dowling',


### PR DESCRIPTION
This allow the type of meter (imperial or metric) to be specified, and add the calculation for an imperial meter.

Also breaks out the calculation so it's less *magic*

Finally allows the calorific value from you gas supplier to be specified.

Closes https://github.com/pavoni/pyloopenergy/issues/8