### PR TITLE
Update Socket.io library version 

### DIFF
--- a/pyloopenergy/loop_energy.py
+++ b/pyloopenergy/loop_energy.py
@@ -10,9 +10,9 @@ import threading
 import logging
 import requests
 
-# Uses Socket.io protocol 0.9 - so is not compatible with 1.0
-# So important to use socketIO-client v 0.5.6
-import socketIO_client
+# Now uses Socket.io protocol 2.0 so bump to use nexus fork
+# see https://pypi.org/project/socketIO-client-nexus/0.7.6/
+import socketIO_client_nexus as socketIO_client
 
 LOG = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-socketIO-client==0.5.7.2
+socketIO-client-nexus==0.7.6

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pyloopenergy',
-      version='0.0.18',
+      version='0.1.0',
       description='Access Loop Energy energy monitors via Socket.IO API',
       url='http://github.com/pavoni/pyloopenergy',
       author='Greg Dowling',


### PR DESCRIPTION
Loop have updated their server (which is good because the Socket.io version was 0.9 - it's now 2.0), so this needs a client library update.

Fixed https://github.com/pavoni/pyloopenergy/issues/30