### PR TITLE
Handle extra exception for new socket library

### DIFF
--- a/pyloopenergy/loop_energy.py
+++ b/pyloopenergy/loop_energy.py
@@ -180,6 +180,7 @@ class LoopEnergy():
             except (
                 ValueError,
                 AttributeError,
+                IndexError,
                 socketIO_client.exceptions.SocketIOError,
                 requests.exceptions.RequestException) as ex:
                 # Looks like ValueError comes from an

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pyloopenergy',
-      version='0.1.2',
+      version='0.1.3',
       description='Access Loop Energy energy monitors via Socket.IO API',
       url='http://github.com/pavoni/pyloopenergy',
       author='Greg Dowling',


### PR DESCRIPTION
When there are connection problems the library seems to throw an `IndexError` exception, so handle this and try and reconnect.

Closes https://github.com/pavoni/pyloopenergy/issues/33